### PR TITLE
Support Node.js 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "reliable"
   ],
   "engines": {
-    "node": ">=12.12.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^12.7.2",
+    "lodash": "^4.17.19",
     "mkdirp": "^1.0.4",
     "promise-resolve-timeout": "^1.2.1",
     "require-inject": "^1.4.4",


### PR DESCRIPTION
As mentioned in sindresorhus/electron-store#103, this package can support earlier Node.js versions. Version 8 failed in a Docker container, but 10 didn't, so that's what I went with.

Also included lodash as a dev dependency, as I presume that you had it installed globally on your machine.