### PR TITLE
Fix memory leak in the Scheduler

### DIFF
--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -45,7 +45,7 @@ const Scheduler = {
 
       queue.push ( resolve );
 
-      if ( queue.length > 1 ) return;
+      if ( queue.length > 1 && queue.length < 100 ) return;
 
       resolve ( () => Scheduler.next ( id ) );
 


### PR DESCRIPTION
Hi! Thanks for this module, our team began using it and it seems good.

This PR is also a sort of report of an issue. We detected a memory leak. If `writeFile` is called many times synchronously, it keeps piling up the `queue` in the scheduler, and because of this `length > 1` if condition, when `length` is a large number, it just returns and allows the queue to keep growing. This led to a memory leak that eventually consumed 100% of the computer's memory, grinding to a full stop.

The proposed change is not necessarily an elegant one, but I've found it to work to prevent the leak. Feel free to not accept this patch and instead find a more elegant solution. In fact, I tried to understand this file, but it seemed hard to understand, so I'll leave the details to you.

Thanks