### PR TITLE
Add license field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/atomically",
   "description": "Read and write files atomically and reliably.",
   "version": "2.0.3",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Specify the license under which the project is available in the package.json so that it can be displayed on [npmjs.org](https://www.npmjs.com/package/atomically) and used by automated tooling for license compliance.

See <https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license> for documentation about this field.