### PR TITLE
chore: add `license` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/atomically",
   "description": "Read and write files atomically and reliably.",
   "version": "2.0.3",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Hi,

If you wouldn't mind accepting this and publishing a release, downstream tools are having trouble reporting the package license dependencies.

Thanks!