### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/atomically",
   "description": "Read and write files atomically and reliably.",
   "version": "2.0.3",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Some tools like for example [LicenseFinder](https://github.com/pivotal/LicenseFinder) rely on the license property from package.json. If not present, the license is reported as unknown