### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "atomically",
   "repository": "github:fabiospampinato/atomically",
   "description": "Read and write files atomically and reliably.",
+  "license": "MIT",
   "version": "2.0.3",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
So that the license properly displays on npmjs.com and is detected by automated tooling