### PR TITLE
fix DEFAULT_USER_{U,G}ID

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,9 +16,9 @@ const DEFAULT_READ_OPTIONS = {};
 
 const DEFAULT_WRITE_OPTIONS = {};
 
-const DEFAULT_USER_UID = os.userInfo ().uid;
+const DEFAULT_USER_UID = process.geteuid ? process.geteuid() : -1;
 
-const DEFAULT_USER_GID = os.userInfo ().gid;
+const DEFAULT_USER_GID = process.getegid ? process.getegid() : -1;
 
 const DEFAULT_TIMEOUT_ASYNC = 7500;
 


### PR DESCRIPTION
Fix #13

On windows, the previously used `os.userInfo()` would return -1: https://nodejs.org/api/os.html#osuserinfooptions

On Posix, `os.userInfo()` would look for `/etc/passwd`, but this does crash when the current user is not in that file, eg. with LDAP.

This for example prevented element-desktop to start, with:
```javascript
App threw an error during load
SystemError [ERR_SYSTEM_ERROR]: A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)
    at Object.userInfo (node:os:359:11)
    at file:///nix/store/zk7ara68h1hnni7bswkmk3aa44n6q7l4-element-desktop-1.11.99/share/element/electron/node_modules/atomically/dist/constants.js:10:29
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async loadApplicationPackage (file:///nix/store/94ispicm94l2sf5lwrfrjsscs22k8cvb-electron-unwrapped-35.3.0/libexec/electron/resources/default_app.asar/main.js:127:9)
    at async file:///nix/store/94ispicm94l2sf5lwrfrjsscs22k8cvb-electron-unwrapped-35.3.0/libexec/electron/resources/default_app.asar/main.js:240:9
```

@micolous: I added you as co-author, because this PR is only implementing your solution. Thanks for it !